### PR TITLE
use ClassTag instead of ClassManifest

### DIFF
--- a/play-dsl-core/src/test/scala/com/iheart/play/dsl/SyntaxSpec.scala
+++ b/play-dsl-core/src/test/scala/com/iheart/play/dsl/SyntaxSpec.scala
@@ -1,5 +1,6 @@
 package com.iheart.play.dsl
 
+import scala.reflect.ClassTag
 import org.joda.time.DateTime
 import org.specs2.concurrent.ExecutionEnv
 import play.api.cache.CacheApi
@@ -191,8 +192,8 @@ class SyntaxSpec extends PlaySpecification {
 
       implicit val cacheApi = new CacheApi {
         def set(key: String, value: Any, expiration: Duration): Unit = ???
-        def get[T: ClassManifest](key: String): Option[T] = ???
-        def getOrElse[A: ClassManifest](key: String, expiration: Duration)(orElse: ⇒ A): A = orElse
+        def get[T: ClassTag](key: String): Option[T] = ???
+        def getOrElse[A: ClassTag](key: String, expiration: Duration)(orElse: ⇒ A): A = orElse
         def remove(key: String): Unit = ???
       }
 
@@ -209,4 +210,6 @@ class SyntaxSpec extends PlaySpecification {
 
     }
   }
+
+
 }

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -4,11 +4,13 @@ import Keys._
 object Projects extends Build {
   lazy val playDSLAll = Project("play-dsl-all", file("."))
     .aggregate(playDSL, playDSLAkka)
+    .settings(commonSettings:_*)
     .settings(noPublishing: _*)
     .settings(Testing.settings: _*)
 
   lazy val playDSL = Project("play-dsl", file("play-dsl-core"))
     .settings(
+      commonSettings ++
       Dependencies.settings ++
       Publish.settings ++
       Format.settings ++
@@ -18,6 +20,7 @@ object Projects extends Build {
   lazy val playDSLAkka = Project("play-dsl-akka", file("play-dsl-akka"))
     .dependsOn(playDSL % "compile->compile;test->test")
     .settings(
+      commonSettings ++
       Dependencies.settings ++
       Publish.settings ++
       Format.settings ++
@@ -27,5 +30,11 @@ object Projects extends Build {
       )
 
   val noPublishing = Seq(publish := (), publishLocal := (), publishArtifact := false)
+
+  val commonSettings = Seq(
+    scalacOptions ++= Seq(
+      "-deprecation"
+    )
+  )
 
 }


### PR DESCRIPTION
Added deprecation flag to all projects, which revealed a usage of deprecated ClassManifest.
